### PR TITLE
auto-qc: Read config from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ Run the [BCCDC-PHL/routine-sequence-qc](https://github.com/BCCDC-PHL/routine-seq
 Usage: java -jar auto-qc.jar OPTIONS
 
 Options:
-  -r, --runs-dir RUN_DIR
-  -e, --exclude EXCLUDE_FILE
+  -c, --config CONFIG_FILE Config file.
   -h, --help
   -v, --version
 ```

--- a/auto-qc/.gitignore
+++ b/auto-qc/.gitignore
@@ -1,0 +1,3 @@
+.nrepl-port
+test_*
+.nextflow*

--- a/auto-qc/README.md
+++ b/auto-qc/README.md
@@ -1,0 +1,35 @@
+# Auto QC
+Run the [BCCDC-PHL/routine-sequence-qc](https://github.com/BCCDC-PHL/routine-sequence-qc) pipeline.
+
+### Usage
+```
+Usage: java -jar auto-qc.jar OPTIONS
+
+Options:
+  -c, --config CONFIG_FILE Config file.
+  -h, --help
+  -v, --version
+```
+
+### Config
+The config file is expected to be in [edn](https://github.com/edn-format/edn) format. 
+
+Example config:
+```edn
+{:run-dirs ["/path/to/run/dir/1"
+	    "/path/to/run/dir/2"
+	    "/path/to/run/dir/3"]
+ :exclude-files ["/path/to/exclude-file-1"
+                 "/path/to/exclude-file-2"]}
+```
+
+### Exclude files
+The files listed under the `:exclude-files` key in the config are lists of directories that should be excluded from analysis.
+They should simply contain one directory name per line (not a full path).
+
+Example exclude file:
+```
+210230_M00123_0123_000000000-AAB12
+210412_M00123_0138_000000000-AD623
+210623_M00426_0165_000000000-B3A52
+```

--- a/auto-qc/config.edn
+++ b/auto-qc/config.edn
@@ -1,0 +1,2 @@
+{:run-dirs []
+ :exclude-files []}

--- a/auto-qc/src/auto_qc/cli.clj
+++ b/auto-qc/src/auto_qc/cli.clj
@@ -1,5 +1,6 @@
 (ns auto-qc.cli
-  (:require [clojure.string :as str]))
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]))
 
 (def version "v0.1.0")
 
@@ -16,8 +17,8 @@
 
 
 (def options
-  [["-r" "--runs-dir RUN_DIR"]
-   ["-e" "--exclude EXCLUDE_FILE"]
+  [["-c" "--config CONFIG_FILE" "Config file"
+    :validate [#(.exists (io/as-file %)) #(str "Config file '" % "' does not exist.")]]
    ["-h" "--help"]
    ["-v" "--version"]])
 


### PR DESCRIPTION
Fixes #1 

Run directories and exclude files are read from a config file in [edn](https://github.com/edn-format/edn) format.

Config file and exclude files are periodically re-loaded so that they can be updated while the tool is running.