### PR TITLE
Timing double analysis

### DIFF
--- a/auto-qc/deps.edn
+++ b/auto-qc/deps.edn
@@ -2,9 +2,7 @@
  :deps {org.clojure/tools.cli {:mvn/version "1.0.206"}
         org.clojure/tools.logging {:mvn/version "1.2.4"}
         ch.qos.logback/logback-classic {:mvn/version "1.2.10"}
-        org.clojure/core.async {:mvn/version "1.5.648"}
-        nrepl/nrepl {:mvn/version "0.9.0"}
-        com.kohlschutter.junixsocket/junixsocket-core {:mvn/version "2.3.2"}}
+        org.clojure/core.async {:mvn/version "1.5.648"}}
  :aliases
  {:build {:deps {io.github.clojure/tools.build {:git/tag "v0.7.5" :git/sha "34727f7"}}
           :ns-default build}}}

--- a/auto-qc/deps.edn
+++ b/auto-qc/deps.edn
@@ -2,7 +2,9 @@
  :deps {org.clojure/tools.cli {:mvn/version "1.0.206"}
         org.clojure/tools.logging {:mvn/version "1.2.4"}
         ch.qos.logback/logback-classic {:mvn/version "1.2.10"}
-        org.clojure/core.async {:mvn/version "1.5.648"}}
+        org.clojure/core.async {:mvn/version "1.5.648"}
+        nrepl/nrepl {:mvn/version "0.9.0"}
+        com.kohlschutter.junixsocket/junixsocket-core {:mvn/version "2.3.2"}}
  :aliases
  {:build {:deps {io.github.clojure/tools.build {:git/tag "v0.7.5" :git/sha "34727f7"}}
           :ns-default build}}}

--- a/auto-qc/src/auto_qc/core.clj
+++ b/auto-qc/src/auto_qc/core.clj
@@ -8,7 +8,6 @@
             [clojure.string :as str]
             [clojure.java.shell :as shell :refer [sh]]
             [clojure.core.async :as async :refer [go go-loop chan onto-chan! <! <!! >! >!! timeout]]
-            [nrepl.server :refer [start-server stop-server]]
             [auto-qc.cli :as cli])
   (:gen-class))
 
@@ -157,16 +156,6 @@
           (log/debug (str "Current config: " (:config @db)))
           (<! (timeout 60000))
           (recur)))))
-
-
-  ;;
-  ;; Start up REPL when configured to do so
-  (when (get-in @db [:config :repl])
-    (let [uuid (java.util.UUID/randomUUID)]
-      (do
-        (sh "mkdir" "-p" "/tmp/auto-qc")
-        (sh "chmod" "700" "/tmp/auto-qc")
-        (defonce server (start-server :socket (str "/tmp/auto-qc/auto-qc-" uuid ".sock"))))))
 
 
   ;;


### PR DESCRIPTION
Fixes #6 
- Added entry to app db with key `:currently-analyzing`. Value is the run directory that is being analyzed, or `nil` if no run is being analyzed
- Only add one run to the `runs-to-analyze` channel, and check that it is not being `currently-analyzed` before adding it to the channel.